### PR TITLE
Fix bug in the output

### DIFF
--- a/src/nick.py
+++ b/src/nick.py
@@ -35,10 +35,8 @@ def index_sequence(seq, settings):
                 seq += seq[0:max_pattern_len]
         fk, rck = nicks(seq, settings.enzymes)
         #remove duplicate hits
-        if len(fk) > 0:
-                while fk[-1][0] >= seqLen:
-                        fk.pop()
-        if len(fk) > 0:
-                while rck[-1][0] >= seqLen:
-                        rck.pop()
+        while len(fk) > 0 and fk[-1][0] >= seqLen:
+                fk.pop()
+        while len(rck) > 0 and rck[-1][0] >= seqLen:
+                rck.pop()
         return fk, rck

--- a/src/noise.py
+++ b/src/noise.py
@@ -118,6 +118,7 @@ def generate_molecule(nicks, size, settings):
         fp = []
         for enzyme in settings.enzymes:
                 fp = fp + false_positives(enzyme['fp'], length, enzyme)
+        fp.sort(key = lambda x: x[0], reverse = False)
         while len(fp) > 0 or (idx < len(nicks) and nicks[idx][0] < end):
                 if len(fp) != 0 and (idx >= len(nicks) or fp[0][0] < nicks[idx][0] - shift):
                         nick = fp.pop(0)


### PR DESCRIPTION
False positives in the multiple nicking case were not properly sorted. This is now fixed.
Additionally: a potential bug in the handling of cross-end nicking sites in the circular genome case has been resolved.
