### PR TITLE
Save intermediate results

### DIFF
--- a/src/omsim/README.rst
+++ b/src/omsim/README.rst
@@ -1,0 +1,4 @@
+# omsim
+Optical Map Simulator  
+
+See the [OMSim manual](https://github.com/biointec/omsim/wiki) to get started.

--- a/src/omsim/bnx.py
+++ b/src/omsim/bnx.py
@@ -33,9 +33,11 @@ class BNX:
                 '''
                 ofile.write('# BNX File Version:\t' + self.settings.bnx_version + '\n')
                 ofile.write('# Label Channels:\t' + '1' + '\n')
-                for i in range(len(self.settings.enzymes)):
-                        if self.settings.enzymes[i]['label'] == label:
-                                ofile.write('# Nickase Recognition Site ' + str(i + 1) + ':\t' + self.settings.enzymes[i]['pattern'] + '\n')
+                idx = 1
+                for eid in self.settings.enzymes:
+                        if self.settings.enzymes[eid]['label'] == label:
+                                ofile.write('# Nickase Recognition Site ' + str(idx) + ':\t' + self.settings.enzymes[eid]['pattern'] + '\n')
+                                idx += 1
                 ofile.write('# Bases per Pixel:\t' + str(int(chip_settings['bpp'])) + '\n')
                 ofile.write('# Software Version:\tomsim-' + self.settings.version + '\n')
                 # TODO: run_data

--- a/src/omsim/bnx.py
+++ b/src/omsim/bnx.py
@@ -80,7 +80,7 @@ class BNX:
                 ofile.write('# Quality Score QX12: Label Intensity for channel 1' + '\n')
         
         
-        def write_bnx_entry(self, info, nicks, ofile, chip_settings):
+        def write_bnx_entry(self, info, nicks, ofile, chip_settings, relative_scan_stretch):
                 count = 0
                 channel = '1'
                 Q1 = 0
@@ -89,13 +89,13 @@ class BNX:
                 q2 = 'QX12'
                 for pos in nicks:
                         count += 1
-                        channel += '\t' + '{0:.2f}'.format(pos)
+                        channel += '\t' + '{0:.2f}'.format(pos * relative_scan_stretch)
                         val = self.noise.next_l_SNR()
                         q1 += '\t' + '{0:.4f}'.format(val)
                         val = self.noise.next_l_AI()
                         q2 += '\t' + '{0:.4f}'.format(val)
                 moleculeID = info[0]
-                length = info[1]
+                length = info[1] * relative_scan_stretch
                 scan = info[2]
                 channel += '\t' + '{0:.2f}'.format(length)
                 backbone = ''

--- a/src/omsim/cmap.py
+++ b/src/omsim/cmap.py
@@ -1,0 +1,71 @@
+class Nicks:
+        def __init__(self):
+                self.nicks = {}
+        
+        def add_nick(self, enzyme, fwd, nick):
+                if not enzyme in self.nicks.keys():
+                        self.nicks[enzyme] = {False: [], True: []}
+                self.nicks[enzyme][fwd].append(nick)
+        
+        def get_nicks(self, enzyme, fwd):
+                if enzyme in self.nicks.keys():
+                        return self.nicks[enzyme][fwd]
+                return []
+        
+        def check(self, seq_len):
+                for enzyme in self.nicks.keys():
+                        for b in [False, True]:
+                                while len(self.nicks[enzyme][b]) > 0 and self.nicks[enzyme][b][-1] >= seq_len:
+                                        self.nicks[enzyme][b].pop()
+        
+        def count(self):
+                count = 0
+                for enzyme in self.nicks.keys():
+                        for b in [False, True]:
+                                count += len(self.nicks[enzyme][b])
+                return count
+
+class Cmap:
+        def __init__(self, iname):
+                self.iname = iname
+                self.seqs = []
+                self.seq_lens = []
+                self.nicks = []
+                self.base_count = 0
+                self.enzymes = []
+        
+        def add_enzyme(self, enzyme):
+                if not enzyme in self.enzymes:
+                        self.enzymes.append(enzyme)
+        
+        def add_meta(self, seq_idx, seq, seq_len):
+                        if seq_idx == len(self.seqs):
+                                self.seqs.append(seq)
+                                self.seq_lens.append(seq_len)
+        
+        def add_nick(self, seq_idx, enzyme=None, fwd=None, nick=None):
+                if seq_idx == len(self.nicks):
+                        n = Nicks()
+                        self.nicks.append(n)
+                if not nick is None:
+                        self.nicks[seq_idx].add_nick(enzyme, fwd, nick)
+        
+        def add_nicks(self, seq_idx, enzyme, fwd, nicks):
+                for nick in nicks:
+                        self.add_nick(seq_idx, enzyme, fwd, nick)
+        
+        def count(self):
+                count = 0
+                for nicks in self.nicks:
+                        count += nicks.count()
+                return count
+        
+        def seq_count(self):
+                return len(self.seqs)
+        
+        def seq_len(self):
+                return sum(self.seq_lens)
+        
+        def check(self):
+                for idx in range(len(self.seq_lens)):
+                        self.nicks[idx].check(self.seq_lens[idx])

--- a/src/omsim/noise.py
+++ b/src/omsim/noise.py
@@ -282,11 +282,11 @@ class Noise:
         def intensity(self, mu, sd, size):
                 mu = float(mu)
                 sd = float(sd)
-                result = -1
-                while result < 0 or result > 1:
-                        result = random.gauss(float(mu), float(sd))
-                return [result]
+      result = norm.rvs(mu, scale=sd, size=size)
+                #print('norm', describe(result))
+                return result
         
+         
         
         def SNR(self, mu, sd, size):
                 mu = float(mu)
@@ -340,7 +340,11 @@ class Noise:
                         self.m_AI = self.intensity(self.settings.molecule_AI_mu, self.settings.molecule_AI_sd, self.settings.sim_batch_size)
                         self.m_AI_idx = 0
                         self.m_AI_len = len(self.m_AI)
-                return self.m_AI[self.m_AI_idx]
+                result = self.m_AI[self.m_AI_idx]
+                if result < 0 or 1 < result:
+                        return self.next_m_AI()
+                else:
+                        return result
         
         
         def next_l_AI(self):
@@ -349,4 +353,8 @@ class Noise:
                         self.l_AI = self.intensity(self.settings.label_AI_mu, self.settings.label_AI_sd, 10 * self.settings.sim_batch_size)
                         self.l_AI_idx = 0
                         self.l_AI_len = len(self.l_AI)
-                return self.l_AI[self.l_AI_idx]
+                result = self.l_AI[self.l_AI_idx]
+                if result < 0 or 1 < result:
+                        return self.next_l_AI()
+                else:
+                        return result

--- a/src/omsim/noise.py
+++ b/src/omsim/noise.py
@@ -295,6 +295,7 @@ class Noise:
                 a = 1.0 + t
                 b = mu * t
                 result = invgamma.rvs(a, scale=b, size=size)
+                #result = [1.0 / random.gammavariate(a, 1.0 / b) for i in range(int(size))]
                 return result
         
         

--- a/src/omsim/noise.py
+++ b/src/omsim/noise.py
@@ -174,7 +174,8 @@ class Noise:
                 meta = [-1, shift]
                 #generate false positives
                 fp = []
-                for enzyme in self.settings.enzymes:
+                for eid in self.settings.enzymes:
+                        enzyme = self.settings.enzymes[eid]
                         fp = fp + self.false_positives(enzyme['fp'], length, enzyme)
                 fp.sort(key=lambda x: x[0], reverse=False)
                 #determine true positives

--- a/src/omsim/noise.py
+++ b/src/omsim/noise.py
@@ -291,10 +291,11 @@ class Noise:
         def SNR(self, mu, sd, size):
                 mu = float(mu)
                 sd = float(sd)
-                t = (mu * mu) / (sd * sd)
-                a = 2.0 + t
-                b = mu * (1.0 + t)
-                return invgamma.rvs(a, scale=b, size=size)
+                t = 1.0 + (mu * mu) / (sd * sd)
+                a = 1.0 + t
+                b = mu * t
+                result = invgamma.rvs(a, scale=b, size=size)
+                return result
         
         
         def randnegbinom(self, mu, sd, size):

--- a/src/omsim/noise.py
+++ b/src/omsim/noise.py
@@ -22,7 +22,7 @@ import random
 from bisect import bisect_left
 from math import exp, sqrt, log, fabs, floor, pi
 import numpy as np
-from scipy.stats import invgamma, nbinom
+from scipy.stats import invgamma, nbinom, norm, describe
 
 
 class Noise:
@@ -282,7 +282,7 @@ class Noise:
         def intensity(self, mu, sd, size):
                 mu = float(mu)
                 sd = float(sd)
-      result = norm.rvs(mu, scale=sd, size=size)
+                result = norm.rvs(mu, scale=sd, size=size)
                 #print('norm', describe(result))
                 return result
         
@@ -296,6 +296,7 @@ class Noise:
                 b = mu * t
                 result = invgamma.rvs(a, scale=b, size=size)
                 #result = [1.0 / random.gammavariate(a, 1.0 / b) for i in range(int(size))]
+                #print('invgamma', describe(result))
                 return result
         
         
@@ -304,7 +305,9 @@ class Noise:
                 sd = float(sd)
                 r = (mu * mu) / (sd * sd - mu)
                 p = 1 - mu / (r + mu)
-                return nbinom.rvs(r, p, size=size)
+                result = nbinom.rvs(r, p, size=size)
+                #print('nbinom', describe(result))
+                return result
         
         
         def next_m_size(self):

--- a/src/omsim/omsim.py
+++ b/src/omsim/omsim.py
@@ -28,7 +28,6 @@ from bnx import BNX
 from settings import Settings
 
 def omsim(settings):
-        noise = Noise(settings)
         # process input
         seqs, seq_lens, fks, rcks = KMP(settings)
         if settings.coverage != 0 and settings.chips != 1:
@@ -36,6 +35,7 @@ def omsim(settings):
         settings.estimated_coverage = int(settings.get_scan_size() * settings.scans_per_chip * settings.chips / float(sum(seq_lens)))
         print('Generating reads on ' + str(settings.chips) + ' chip' + ('' if settings.chips == 1 else 's') + ', estimated coverage: ' + str(settings.estimated_coverage) + 'x.')
         #bedfile = open(settings.prefix + '.bed', 'w')
+        noise = Noise(settings)
         bnx = BNX(settings, noise)
         # generate reads
         for chip in range(1, settings.chips + 1):

--- a/src/omsim/omsim.py
+++ b/src/omsim/omsim.py
@@ -120,6 +120,19 @@ def import_input(settings):
                 idx += 1
         return seqs, seq_lens, fks, rcks, imported
 
+
+def get_rcns(settings, fks, seq_lens):
+        rcns = []
+        for idx in range(len(fks)):
+                f = fks[idx]
+                l = seq_lens[idx]
+                e = {}
+                for en in settings.enzymes:
+                        e[en['id']] = en 
+                rcns.append(list(reversed([(l - pos[0] - len(e[pos[2]['id']]['pattern']), pos[1], pos[2]) for pos in f])))
+        return rcns
+
+
 def omsim(settings):
         # process input
         seqs, seq_lens, fks, rcks, imported = import_input(settings)
@@ -127,6 +140,7 @@ def omsim(settings):
                 print('Imported ' + str(sum(len(f) for f in fks)) + ' nicks in ' + str(sum(seq_lens)) + 'bp.')
         else:
                 seqs, seq_lens, fks, rcks = KMP(settings)
+        rcks = get_rcns(settings, fks, seq_lens)
         # write processed input
         write_processed_input(settings, seqs, seq_lens, fks, rcks, mod=('imported' if imported else ''))
         #estimate coverage

--- a/src/omsim/omsim.py
+++ b/src/omsim/omsim.py
@@ -35,7 +35,7 @@ def omsim(settings):
                 settings.chips = 1 + int(sum(seq_lens) * settings.coverage / (settings.scans_per_chip * settings.get_scan_size()))
         settings.estimated_coverage = int(settings.get_scan_size() * settings.scans_per_chip * settings.chips / float(sum(seq_lens)))
         print('Generating reads on ' + str(settings.chips) + ' chip' + ('' if settings.chips == 1 else 's') + ', estimated coverage: ' + str(settings.estimated_coverage) + 'x.')
-        bedfile = open(settings.prefix + '.bed', 'w')
+        #bedfile = open(settings.prefix + '.bed', 'w')
         bnx = BNX(settings, noise)
         # generate reads
         for chip in range(1, settings.chips + 1):
@@ -55,8 +55,8 @@ def omsim(settings):
                         stretch.append(noise.scan_stretch_factor(chip_settings['stretch_factor']))
                         for l, m, meta in noise.generate_scan(seq_lens, fks, rcks):
                                         moleculeID += 1
-                                        for mol in meta:
-                                                bedfile.write(seqs[mol[0]] + '\t' + str(mol[1]) + '\t' + str(mol[1] + l) + '\t' + str(moleculeID) + '\n')
+                                        #for mol in meta:
+                                        #        bedfile.write(seqs[mol[0]] + '\t' + str(mol[1]) + '\t' + str(mol[1] + l) + '\t' + str(moleculeID) + '\n')
                                         molecule = {}
                                         for label in settings.labels:
                                                 molecule[label] = []
@@ -77,7 +77,7 @@ def omsim(settings):
                                 moleculeID += 1
                                 bnx.write_bnx_entry((moleculeID, l, s), m, ofile[label], chip_settings)
                         ofile[label].close()
-        bedfile.close()
+        #bedfile.close()
         print('Finished processing ' + settings.name + '.\n')
 
 

--- a/src/omsim/omsim.py
+++ b/src/omsim/omsim.py
@@ -49,10 +49,10 @@ def omsim(settings):
                         molecules[label] = []
                 # generate reads
                 moleculeID = 0
-                stretch = []
+                relative_stretch = []
                 for scan in range(1, settings.scans_per_chip + 1):
                         chip_settings['scans'] += 1
-                        stretch.append(noise.scan_stretch_factor(chip_settings['stretch_factor']))
+                        relative_stretch.append(noise.scan_stretch_factor(chip_settings['stretch_factor']) / chip_settings['stretch_factor'])
                         for l, m, meta in noise.generate_scan(seq_lens, fks, rcks):
                                         moleculeID += 1
                                         for mol in meta:
@@ -75,7 +75,7 @@ def omsim(settings):
                         bnx.write_bnx_header(ofile[label], label, chip_settings)
                         for l, m, s in molecules[label]:
                                 moleculeID += 1
-                                bnx.write_bnx_entry((moleculeID, l, s), m, ofile[label], chip_settings)
+                                bnx.write_bnx_entry((moleculeID, l, s), m, ofile[label], chip_settings, relative_stretch[s - 1])
                         ofile[label].close()
         bedfile.close()
         print('Finished processing ' + settings.name + '.\n')

--- a/src/omsim/omsim.py
+++ b/src/omsim/omsim.py
@@ -29,6 +29,31 @@ from bnx import BNX
 from settings import Settings
 import struct
 
+def write_processed_input(settings, seqs, seq_lens, fks, rcks, mod=''):
+        prefix = settings.prefix + mod
+        for idx in range(len(fks)):
+                names = ['seqs', 'lens', 'fns', 'rcns']
+                meta_file = open(prefix + '.' + str(idx) + '.meta.byte', 'w')
+                for j in range(4):
+                        array = [seqs, seq_lens, fks, rcks][j][idx]
+                        if j in [0, 1]:
+                                file = open(prefix + '.' + str(idx) + '.' + names[j] + '.byte', 'w')
+                                file.write(str(array))
+                                file.close()
+                        else:
+                                arrays = {}
+                                for enzyme in settings.enzymes:
+                                        arrays[enzyme['id']] = [[], []]
+                                for pos in array:
+                                        arrays[pos[2]['id']][int(pos[1])].append(pos[0])
+                                for enzyme in settings.enzymes:
+                                        for b in [0, 1]:
+                                                file_name = prefix + '.' + str(idx) + '.' + names[j] + '.' + enzyme['id'] + '.' + str(b) + '.byte'
+                                                file = open(file_name, 'wb')
+                                                file.write(struct.pack('i' * len(arrays[enzyme['id']][b]), *(arrays[enzyme['id']][b])))
+                                                meta_file.write(enzyme['id'] + '\t' + str(b) + '\t' + str(len(arrays[enzyme['id']][b])) + '\t' + names[j] + '\t' + file_name + '\n')
+                                                file.close()
+                meta_file.close()
 def omsim(settings):
         # process input
         seqs, seq_lens, fks, rcks = KMP(settings)

--- a/src/omsim/omsim.py
+++ b/src/omsim/omsim.py
@@ -109,7 +109,7 @@ def import_input(settings):
                                                 if idxs[e['id']][b] >= len(temp[e['id']][b]):
                                                         continue
                                                 if m is None or temp[e['id']][b][idxs[e['id']][b]] < m[0]:
-                                                        m = [temp[e['id']][b][idxs[e['id']][b]], b, e]
+                                                        m = (temp[e['id']][b][idxs[e['id']][b]], b, e)
                                 if m is not None:
                                         tn.append(m)
                                         idxs[m[2]['id']][m[1]] += 1

--- a/src/omsim/omsim.py
+++ b/src/omsim/omsim.py
@@ -142,7 +142,7 @@ def omsim(settings):
                 seqs, seq_lens, fks, rcks = KMP(settings)
         rcks = get_rcns(settings, fks, seq_lens)
         # write processed input
-        write_processed_input(settings, seqs, seq_lens, fks, rcks, mod=('imported' if imported else ''))
+        write_processed_input(settings, seqs, seq_lens, fks, rcks, mod=('.imported' if imported else ''))
         #estimate coverage
         if settings.coverage != 0 and settings.chips != 1:
                 settings.chips = 1 + int(sum(seq_lens) * settings.coverage / (settings.scans_per_chip * settings.get_scan_size()))

--- a/src/omsim/omsim.py
+++ b/src/omsim/omsim.py
@@ -20,12 +20,14 @@
 '''
 
 import sys
+import os
 import xml.etree.ElementTree
 
 from util import double_stranded_multi_KMP_from_fasta as KMP
 from noise import Noise
 from bnx import BNX
 from settings import Settings
+import struct
 
 def omsim(settings):
         # process input

--- a/src/omsim/omsim.py
+++ b/src/omsim/omsim.py
@@ -122,7 +122,14 @@ def import_input(settings):
 
 def omsim(settings):
         # process input
-        seqs, seq_lens, fks, rcks = KMP(settings)
+        seqs, seq_lens, fks, rcks, imported = import_input(settings)
+        if imported:
+                print('Imported ' + str(sum(len(f) for f in fks)) + ' nicks in ' + str(sum(seq_lens)) + 'bp.')
+        else:
+                seqs, seq_lens, fks, rcks = KMP(settings)
+        # write processed input
+        write_processed_input(settings, seqs, seq_lens, fks, rcks, mod=('imported' if imported else ''))
+        #estimate coverage
         if settings.coverage != 0 and settings.chips != 1:
                 settings.chips = 1 + int(sum(seq_lens) * settings.coverage / (settings.scans_per_chip * settings.get_scan_size()))
         settings.estimated_coverage = int(settings.get_scan_size() * settings.scans_per_chip * settings.chips / float(sum(seq_lens)))

--- a/src/omsim/settings.py
+++ b/src/omsim/settings.py
@@ -91,17 +91,18 @@ class Settings:
                 return self.scan_size * MEGA
 
         def set_patterns(self):
-                for idx in range(len(self.enzymes)):
-                        enzyme = self.enzymes[idx]
+                enzymes = {}
+                for enzyme in self.enzymes:
                         found = False
                         for e in self.enzyme_xml:
                                 if e['id'] == enzyme['id']:
                                         e['label'] = enzyme['label']
                                         if not enzyme['label'] in self.labels:
                                                 self.labels.append(enzyme['label'])
-                                        self.enzymes[idx] = e
+                                        enzymes[e['id']] = e
                                         found = True
                                         break
                         if not found:
-                                print('Unkown nicking enzyme: ' + enzyme['id'])
+                                print('Unknown nicking enzyme: ' + enzyme['id'])
                                 exit()
+                self.enzymes = enzymes

--- a/src/omsim/setup.py
+++ b/src/omsim/setup.py
@@ -1,0 +1,99 @@
+import codecs
+import os
+import re
+
+from setuptools import setup, find_packages
+
+import sys
+from cx_Freeze import setup, Executable
+
+import scipy
+includefiles_list=[]
+scipy_path = os.path.dirname(scipy.__file__)
+includefiles_list.append(scipy_path)
+
+###################################################################
+
+NAME = "omsim"
+PACKAGES = find_packages(where="")
+META_PATH = "__init__.py"
+KEYWORDS = ["optical maps"]
+CLASSIFIERS = [
+        "Development Status :: 0 - Unstable",
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "License :: OSI Approved :: GPL2 License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+]
+INSTALL_REQUIRES = ["scipy"]
+
+###################################################################
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def read(*parts):
+        """
+        Build an absolute path from *parts* and and return the contents of the
+        resulting file.  Assume UTF-8 encoding.
+        """
+        with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
+                return f.read()
+
+
+META_FILE = read(META_PATH)
+
+
+def find_meta(meta):
+        """
+        Extract __*meta*__ from META_FILE.
+        """
+        meta_match = re.search(
+                r"^__{meta}__ = ['\"]([^'\"]*)['\"]".format(meta=meta),
+                META_FILE, re.M
+        )
+        if meta_match:
+                return meta_match.group(1)
+        raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
+
+
+base = 'Console'
+if sys.platform == 'win32':
+        base = 'Win32GUI'
+
+options = {
+        'build_exe': {
+                'include_files': includefiles_list,
+                'optimize': '2'
+    }
+}
+
+executables = [
+        Executable('__main__.py', base=base)
+]
+
+if __name__ == "__main__":
+        setup(
+                name=NAME,
+                description=find_meta("description"),
+                license=find_meta("license"),
+                url=find_meta("uri"),
+                version=find_meta("version"),
+                author=find_meta("author"),
+#                author_email=find_meta("email"),
+                maintainer=find_meta("author"),
+#                maintainer_email=find_meta("email"),
+                keywords=KEYWORDS,
+                long_description=read("README.rst"),
+                packages=PACKAGES,
+                package_dir={"": ".."},
+                zip_safe=False,
+                classifiers=CLASSIFIERS,
+                install_requires=INSTALL_REQUIRES,
+                executables=executables,
+                options=options
+        )


### PR DESCRIPTION
This merge adds the following functionality:
- cx_freeze support, allowing packaging in a redistributable executable without dependencies
- saving and importing nicking positions, allowing faster repeat experiments with new parameters
- improve stretch factor implementation
  Additionally:
- additional classes have been added to streamline the exporting and importing procedure, these might be further used for the actual simulation, this should result in a lower space usage (but at a cost in run time?)
- additional random variables are computed in batches
- some of the code has been restructured
