### PR TITLE
Fixed bug setting directory for multiple simulations incorrectly.

### DIFF
--- a/omsim/src/omsim/omsim.py
+++ b/omsim/src/omsim/omsim.py
@@ -253,9 +253,10 @@ def xml_enzyme_parse(xml_file):
 
 def xml_input_parse(xml_file):
         s = []
+        directory = os.path.dirname(os.path.realpath(xml_file))
         for child in xml.etree.ElementTree.parse(xml_file).getroot():
                 settings = {}
-                settings['directory'] = os.path.dirname(os.path.realpath(xml_file))
+                settings['directory'] = directory
                 os.chdir(settings['directory'])
                 for entry in child:
                         if entry.tag == 'enzymes':


### PR DESCRIPTION
I found a bug that appends the relative XML path each time you run a simulation. If you run multiple simulations with one XML, you will get an error for incorrect paths.