### PR TITLE
Fixed typos and BNX header.

### DIFF
--- a/example/Fixed-SF-Estimate/example-auto-chip-sf.xml
+++ b/example/Fixed-SF-Estimate/example-auto-chip-sf.xml
@@ -60,13 +60,13 @@
                 <nick_sd>50</nick_sd>
                 <fragile_same>-1</fragile_same>
                 <fragile_opposite>-1</fragile_opposite>
-                <fragile_treshold>0</fragile_treshold>
-                <!--Factor determining the steepness of the fragile location cutoff when the distance is less than fragile_treshold away from the 50% point-->
+                <fragile_threshold>0</fragile_threshold>
+                <!--Factor determining the steepness of the fragile location cutoff when the distance is less than fragile_threshold away from the 50% point-->
                 <fragile_factor>3</fragile_factor>
                 <!--Distance between labels where there is 50% chance of collapsing them unto one label-->
                 <label_mu>1500</label_mu>
-                <!--Similar to fragile_treshold, but now for label collapsing-->
-                <label_treshold>500</label_treshold>
+                <!--Similar to fragile_threshold, but now for label collapsing-->
+                <label_threshold>500</label_threshold>
                 <!--Similar to fragile_factor, but now for label collapsing-->
                 <label_factor>100</label_factor>
                 <!--Percent of the reads that will be extend as a chimera-->

--- a/example/Fixed-SF-Estimate/example-fixed-chip-sf.xml
+++ b/example/Fixed-SF-Estimate/example-fixed-chip-sf.xml
@@ -60,13 +60,13 @@
                 <nick_sd>50</nick_sd>
                 <fragile_same>-1</fragile_same>
                 <fragile_opposite>-1</fragile_opposite>
-                <fragile_treshold>0</fragile_treshold>
-                <!--Factor determining the steepness of the fragile location cutoff when the distance is less than fragile_treshold away from the 50% point-->
+                <fragile_threshold>0</fragile_threshold>
+                <!--Factor determining the steepness of the fragile location cutoff when the distance is less than fragile_threshold away from the 50% point-->
                 <fragile_factor>3</fragile_factor>
                 <!--Distance between labels where there is 50% chance of collapsing them unto one label-->
                 <label_mu>1500</label_mu>
-                <!--Similar to fragile_treshold, but now for label collapsing-->
-                <label_treshold>500</label_treshold>
+                <!--Similar to fragile_threshold, but now for label collapsing-->
+                <label_threshold>500</label_threshold>
                 <!--Similar to fragile_factor, but now for label collapsing-->
                 <label_factor>100</label_factor>
                 <!--Percent of the reads that will be extend as a chimera-->

--- a/example/Irys/example.xml
+++ b/example/Irys/example.xml
@@ -65,14 +65,14 @@
                 <fragile_same>50</fragile_same>
                 <!--Distance at which fragile sites on opposite strands have 50% chance to break-->
                 <fragile_opposite>150</fragile_opposite>
-                <!--If the distance is further away than treshold from the 50% point, then break chance is 100% (left) or 0% (right)-->
-                <fragile_treshold>25</fragile_treshold>
-                <!--Factor determining the steepness of the fragile location cutoff when the distance is less than fragile_treshold away from the 50% point-->
+                <!--If the distance is further away than threshold from the 50% point, then break chance is 100% (left) or 0% (right)-->
+                <fragile_threshold>25</fragile_threshold>
+                <!--Factor determining the steepness of the fragile location cutoff when the distance is less than fragile_threshold away from the 50% point-->
                 <fragile_factor>3</fragile_factor>
                 <!--Distance between labels where there is 50% chance of collapsing them unto one label-->
                 <label_mu>1500</label_mu>
-                <!--Similar to fragile_treshold, but now for label collapsing-->
-                <label_treshold>500</label_treshold>
+                <!--Similar to fragile_threshold, but now for label collapsing-->
+                <label_threshold>500</label_threshold>
                 <!--Similar to fragile_factor, but now for label collapsing-->
                 <label_factor>100</label_factor>
                 <!--Percent of the reads that will be extend as a chimera-->

--- a/example/Noiseless/example.xml
+++ b/example/Noiseless/example.xml
@@ -35,11 +35,11 @@
                 <!--disable fragile sites-->
                 <fragile_same>-1</fragile_same>
                 <fragile_opposite>-1</fragile_opposite>
-                <fragile_treshold>0</fragile_treshold>
+                <fragile_threshold>0</fragile_threshold>
                 <fragile_factor>0</fragile_factor>
                 <!--disable neighbouring label collapse-->
                 <label_mu>-1</label_mu>
-                <label_treshold>0</label_treshold>
+                <label_threshold>0</label_threshold>
                 <label_factor>0</label_factor>
                 <!--disable chimeric reads-->
                 <chimera_rate>0</chimera_rate>

--- a/example/Saphyr/example.xml
+++ b/example/Saphyr/example.xml
@@ -59,12 +59,12 @@
                 <!--disable fragile sites-->
                 <fragile_same>-1</fragile_same>
                 <fragile_opposite>-1</fragile_opposite>
-                <fragile_treshold>0</fragile_treshold>
+                <fragile_threshold>0</fragile_threshold>
                 <fragile_factor>0</fragile_factor>
                 <!--Distance between labels where there is 50% chance of collapsing them unto one label-->
                 <label_mu>1500</label_mu>
-                <!--Similar to fragile_treshold, but now for label collapsing-->
-                <label_treshold>500</label_treshold>
+                <!--Similar to fragile_threshold, but now for label collapsing-->
+                <label_threshold>500</label_threshold>
                 <!--Similar to fragile_factor, but now for label collapsing-->
                 <label_factor>100</label_factor>
                 <!--Percent of the reads that will be extend as a chimera-->

--- a/omsim/src/omsim/merge.py
+++ b/omsim/src/omsim/merge.py
@@ -37,7 +37,7 @@ def merge_bnx(out_bnx, in_bnxs):
         elif line[:28] == '# Nickase Recognition Site 1':
             for label in range(0, len(in_bnxs)):
                 out_bnx_file.write('# Nickase Recognition Site ' + str(label + 1) + headers[label][idx][28:])
-        elif line[:3] == '#1h':
+        elif line[:3] == '#1':
             for label in range(0, len(in_bnxs)):
                 out_bnx_file.write('#' + str(label + 1) + headers[label][idx][2:])
                 out_bnx_file.write('#' + str(label + 1) + headers[label][idx + 1][2:])
@@ -45,7 +45,7 @@ def merge_bnx(out_bnx, in_bnxs):
             for label in range(0, len(in_bnxs)):
                 out_bnx_file.write(headers[label][idx][:18] + str(label + 1) + headers[label][idx][19:-2] + str(label + 1) + '\n')
                 out_bnx_file.write(headers[label][idx + 1][:18] + str(label + 1) + headers[label][idx + 1][19:-2] + str(label + 1) + '\n')
-        elif line[:3] != '#1h' and line[:15] != '# Quality Score':
+        elif line[:3] != '#1' and line[:15] != '# Quality Score':
             out_bnx_file.write(line)
         idx += 1
 

--- a/omsim/src/omsim/noise.py
+++ b/omsim/src/omsim/noise.py
@@ -106,10 +106,10 @@ class Noise:
                 else:
                         cutoff = self.settings.fragile_opposite
                 dist = abs(curr[0] - prev[0])
-                if dist < cutoff - self.settings.fragile_treshold:
+                if dist < cutoff - self.settings.fragile_threshold:
                         # don't break, nicks are so close that molecule does not become fragile
                         return False
-                elif cutoff + self.settings.fragile_treshold < dist:
+                elif cutoff + self.settings.fragile_threshold < dist:
                         # don't break, nicks are too far apart for molecule to become fragile
                         return False
                 else:
@@ -237,7 +237,7 @@ class Noise:
                         return m
                 mol = []
                 mu = self.settings.label_mu
-                t = self.settings.label_treshold
+                t = self.settings.label_threshold
                 f = self.settings.label_factor
                 prev = None
                 for curr in m:

--- a/omsim/src/omsim/settings.py
+++ b/omsim/src/omsim/settings.py
@@ -44,10 +44,10 @@ class Settings:
                 self.nick_sd = 50
                 self.fragile_same = 50
                 self.fragile_opposite = 150
-                self.fragile_treshold = 25
+                self.fragile_threshold = 25
                 self.fragile_factor = 3
                 self.label_mu = 1500
-                self.label_treshold = 500
+                self.label_threshold = 500
                 self.label_factor = 100
                 self.chimera_rate = 0.01
                 self.chimera_mu = 1500

--- a/omsimgui/src/configuration.hpp
+++ b/omsimgui/src/configuration.hpp
@@ -119,13 +119,13 @@ struct configuration {
                 set(wxT("min_nicks"), wxT("1"), wxT("Minimal Number of Nicks"));
 
                 set(wxT("label_mu"), wxT("1500"), wxT("Label Merge: Mean"));
-                set(wxT("label_treshold"), wxT("500"), wxT("Label Merge: Treshold"));
+                set(wxT("label_threshold"), wxT("500"), wxT("Label Merge: Threshold"));
                 set(wxT("label_factor"), wxT("100"), wxT("Label Merge: Factor"));
                 set(wxT("nick_sd"), wxT("50"), wxT("Label position: Standard Deviation"));
 
                 set(wxT("fragile_same"), wxT("50"), wxT("Fragile Distance: Same Strand Mean"));
                 set(wxT("fragile_opposite"), wxT("150"), wxT("Fragile Distance: Opposite Strand Mean"));
-                set(wxT("fragile_treshold"), wxT("25"), wxT("Fragile Distance: Treshold"));
+                set(wxT("fragile_threshold"), wxT("25"), wxT("Fragile Distance: Threshold"));
                 set(wxT("fragile_factor"), wxT("3"), wxT("Fragile Distance: Factor"));
 
                 set(wxT("chimera_rate"), wxT("0.01"), wxT("Chimera Rate"));

--- a/test/ecoli/example.xml
+++ b/test/ecoli/example.xml
@@ -64,14 +64,14 @@
                 <fragile_same>50</fragile_same>
                 <!--Distance at which fragile sites on opposite strands have 50% chance to break-->
                 <fragile_opposite>150</fragile_opposite>
-                <!--If the distance is further away than treshold from the 50% point, then break chance is 100% (left) or 0% (right)-->
-                <fragile_treshold>25</fragile_treshold>
-                <!--Factor determining the steepness of the fragile location cutoff when the distance is less than fragile_treshold away from the 50% point-->
+                <!--If the distance is further away than threshold from the 50% point, then break chance is 100% (left) or 0% (right)-->
+                <fragile_threshold>25</fragile_threshold>
+                <!--Factor determining the steepness of the fragile location cutoff when the distance is less than fragile_threshold away from the 50% point-->
                 <fragile_factor>3</fragile_factor>
                 <!--Distance between labels where there is 50% chance of collapsing them unto one label-->
                 <label_mu>1500</label_mu>
-                <!--Similar to fragile_treshold, but now for label collapsing-->
-                <label_treshold>500</label_treshold>
+                <!--Similar to fragile_threshold, but now for label collapsing-->
+                <label_threshold>500</label_threshold>
                 <!--Similar to fragile_factor, but now for label collapsing-->
                 <label_factor>100</label_factor>
                 <!--Percent of the reads that will be extend as a chimera-->

--- a/test/hsapiens/example.xml
+++ b/test/hsapiens/example.xml
@@ -38,10 +38,10 @@
         <nick_sd>50</nick_sd>
         <fragile_same>50</fragile_same>
         <fragile_opposite>150</fragile_opposite>
-        <fragile_treshold>25</fragile_treshold>
+        <fragile_threshold>25</fragile_threshold>
         <fragile_factor>3</fragile_factor>
         <label_mu>1500</label_mu>
-        <label_treshold>500</label_treshold>
+        <label_threshold>500</label_threshold>
         <label_factor>100</label_factor>
         <chimera_rate>0.01</chimera_rate>
         <chimera_mu>1500</chimera_mu>


### PR DESCRIPTION
I fixed a bug that reported the line starting with '#1f' twice in the BNX header as well as the typos in all occurrences of the word 'threshold'.