### PR TITLE
Fixed bug reading all input paths relative to XML file instead of current directory.

### DIFF
--- a/omsim/src/omsim/omsim.py
+++ b/omsim/src/omsim/omsim.py
@@ -32,7 +32,7 @@ from cmap import Cmap, Nicks
 from merge import merge_bnx
 
 def write_processed_input(settings, cmaps):
-        prefix = settings.byte_prefix
+        prefix = settings.directory + '/' + settings.byte_prefix
         mfn = prefix + '.byte.meta'
         meta_file = open(mfn, 'w')
         nfn = prefix + '.byte.nicks'
@@ -75,7 +75,7 @@ def write_processed_input(settings, cmaps):
 
 def import_input(settings):
         cmaps = {}
-        prefix = settings.byte_prefix
+        prefix = settings.directory + '/' + settings.byte_prefix
         if os.path.isfile(prefix + '.byte.meta'):
                 meta_file = open(prefix + '.byte.meta')
                 byte_file = open(prefix + '.byte.nicks', 'rb')
@@ -149,8 +149,6 @@ def get_rns(settings, fns, seq_lens):
 
 
 def omsim(settings):
-        # cd to the directory containing the configuration file
-        os.chdir(settings.directory)
         # process input
         cmaps = import_input(settings)
         print('Imported ' + str(sum(cmaps[iname].count() for iname in cmaps)) + ' nicks in ' + str(sum(cmaps[iname].seq_len() for iname in cmaps)) + 'bp.')
@@ -211,9 +209,10 @@ def omsim(settings):
                                         chip_settings['molecule_count'] += 1
                                         chip_settings['size'] += l
                 # write output
+                prefix = settings.directory + '/' + settings.prefix
                 for label in settings.labels:
                         moleculeID = 0
-                        ofile = open(settings.prefix + '.' + label + '.' + str(chip) + '.bnx', 'w')
+                        ofile = open(prefix + '.' + label + '.' + str(chip) + '.bnx', 'w')
                         bnx.write_bnx_header(ofile, label, chip_settings)
                         for l, m, s, meta in molecules[label]:
                                 moleculeID += 1
@@ -221,7 +220,7 @@ def omsim(settings):
                         ofile.close()
                 # write bed file
                 if settings.bed_file:
-                        bed_file = open(settings.prefix + '.' + str(chip) + '.bed', 'w')
+                        bed_file = open(prefix + '.' + str(chip) + '.bed', 'w')
                         moleculeID = 0
                         for _, _, _, meta in molecules[settings.labels[0]]:
                                 moleculeID += 1
@@ -236,7 +235,7 @@ def omsim(settings):
                                         bed_file.write(molecule_pos + molecule_id)
                         bed_file.close()
                 if not settings.do_not_merge_bnx:
-                        merge_bnx(settings.prefix + '.' + str(chip) + '.bnx', [settings.prefix + '.' + label + '.' + str(chip) + '.bnx' for label in settings.labels])
+                        merge_bnx(prefix + '.' + str(chip) + '.bnx', [prefix + '.' + label + '.' + str(chip) + '.bnx' for label in settings.labels])
                 print('Finished chip ' + str(chip) + '/' + str(settings.chips))
         print('Finished processing ' + settings.name + '.\n')
 
@@ -258,9 +257,7 @@ def xml_input_parse(xml_file):
         s = []
         directory = os.path.dirname(os.path.realpath(xml_file))
         for child in xml.etree.ElementTree.parse(xml_file).getroot():
-                settings = {}
-                settings['directory'] = directory
-                os.chdir(settings['directory'])
+                settings = {'directory': directory}
                 for entry in child:
                         if entry.tag == 'enzymes':
                                 enzymes = []


### PR DESCRIPTION
I fixed what I consider a possible bug, i.e., that all input paths (e.g. the reference files used for sampling) are relative to the directory in which the XML file is located instead of the current directory. Feel free to ignore my changes if this behavior is desired though. 